### PR TITLE
modules/ini: build fsm-context.scm first

### DIFF
--- a/modules/ini/Makefile.am
+++ b/modules/ini/Makefile.am
@@ -20,12 +20,16 @@
 include $(top_srcdir)/build-aux/am/guile.am
 
 SOURCES = \
-	fsm-context.scm \
 	fsm.scm	\
 	fsm-context-ini.scm
 
+BUILT_SOURCES = \
+	fsm-context.scm
+
+INSTALL += \
+	fsm-context.scm
+
 EXTRA_DIST += \
-	fsm-context.scm \
 	fsm.scm	\
 	fsm.puml
 


### PR DESCRIPTION
Otherwise it might be that fsm-context.scm is not built first and therefore compilation of fsm-context-ini.scm will fail.