### PR TITLE
ini/fsm.puml: Support files with no trailing newline.

### DIFF
--- a/modules/ini/fsm.puml
+++ b/modules/ini/fsm.puml
@@ -84,7 +84,7 @@ trim_section_property_value --> read_section_property_value: char:newline?
 trim_section_property_value --> read_section_property_value: guard:#t -> push-event-to-buffer
 
 read_section_property_value: Read the section property value.
-read_section_property_value ---> [*]: char:eof-object?
+read_section_property_value --> read_section_content: char:eof-object? -> action:append-property
 read_section_property_value --> read_section_content: char:newline? -> action:append-property
 read_section_property_value -> read_section_property_value: guard:#t -> push-event-to-buffer
 @enduml

--- a/tests/ini.scm
+++ b/tests/ini.scm
@@ -1,6 +1,7 @@
 (add-to-load-path (getenv "abs_top_srcdir"))
 
-(use-modules (srfi srfi-64)
+(use-modules (srfi srfi-2)
+             (srfi srfi-64)
              (srfi srfi-26)
              (oop goops)
              (tests common)
@@ -61,6 +62,16 @@ file=\"payroll.dat\"
              (global (cdar data)))
         (and (equal? (caar global) 'comment)
              (equal? (cdar global) " last modified 1 April 2001 by John Doe"))))))
+
+;; See <https://github.com/artyom-poptsov/guile-ini/issues/6>.
+(test-assert "ini->scm: No trailing newline"
+  (with-input-from-string
+      (string-drop-right %test-ini 1)
+    (lambda ()
+      (and-let* ((data (ini->scm (current-input-port) #:read-comments? #f))
+                 (database (assoc-ref data "database"))
+                 (file (assoc-ref database "file")))
+        (equal? "\"payroll.dat\"" file)))))
 
 ;; See
 ;; <https://github.com/artyom-poptsov/guile-ini/issues/5>


### PR DESCRIPTION
* modules/ini/fsm.puml (read_section_property_value): Continue normally on EOF.
* tests/ini.scm: Add new test for no trailing newline.

Fixes <https://github.com/artyom-poptsov/guile-ini/issues/6>.